### PR TITLE
Add yarn and update node version

### DIFF
--- a/extra/homebrew.sh
+++ b/extra/homebrew.sh
@@ -12,6 +12,7 @@ brew update
 brew install node@10
 brew install git
 brew install awscli
+brew install yarn
 
 ## Dotfiles management
 brew tap thoughtbot/formulae

--- a/extra/homebrew.sh
+++ b/extra/homebrew.sh
@@ -9,7 +9,7 @@ brew update
 ###############################################################################
 # CLI
 
-brew install node
+brew install node@10
 brew install git
 brew install awscli
 


### PR DESCRIPTION
-Downgrade node version to 10.16.3, as "brew install node" installs the latest node version which is incompatible with some of the packages in the /front repo

-Automatically install yarn, which is /front-client repo's package manager