### PR TITLE
update usage of deprecated brew cask install command

### DIFF
--- a/extra/homebrew.sh
+++ b/extra/homebrew.sh
@@ -21,12 +21,12 @@ brew install thoughtbot/formulae/rcm
 ###############################################################################
 # Softwares
 
-brew cask install front
+brew install --cask front
 
-brew cask install 1password
-brew cask install dropbox
-brew cask install google-chrome
-brew cask install kap
-brew cask install pritunl
-brew cask install sequel-pro
-brew cask install slack
+brew install --cask 1password
+brew install --cask dropbox
+brew install --cask google-chrome
+brew install --cask kap
+brew install --cask pritunl
+brew install --cask sequel-pro
+brew install --cask slack


### PR DESCRIPTION
as of 2.7, `brew cask install` has been deleted in favor of `brew install --cask`. Changing the `homebrew.sh` file to reflect that. I also tested with version 2.6 to ensure backwards compatibility in case user has `brew update` disabled for any reason.

For more info:
https://github.com/Homebrew/discussions/discussions/340#discussioncomment-232364