### PR TITLE
Don't open editor for merge commits

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -3,6 +3,7 @@
 
 [color]
   ui = always
+  mergeoptions = --no-edit
 
 [core]
   excludesfile = ~/.gitignore


### PR DESCRIPTION
I've never seen anyone at Front edit merge commits. 

`git merge master --edit` or `git merge master -m "My super merge"` will override this.