### PR TITLE
Switch the default diffing algorithm to histogram

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -31,3 +31,7 @@
 
 [merge]
   ff = false
+
+# Histogram is (unnoticeably) slower, but it generates much cleaner diffs
+[diff]
+  algorithm = histogram


### PR DESCRIPTION
I've had it enabled for 2 months without any issues. More info: https://link.springer.com/article/10.1007/s10664-019-09772-z